### PR TITLE
Added Vehicle and Skateboard Prices Module

### DIFF
--- a/Core.cs
+++ b/Core.cs
@@ -14,6 +14,7 @@ using Lithium.Modules.Shops;
 using Lithium.Modules.StackSizes;
 using Lithium.Modules.Storyline;
 using Lithium.Modules.TrashGrabber;
+using Lithium.Modules.VehiclePrices;
 using Lithium.Modules.WateringCans;
 using MelonLoader;
 using UnityEngine;
@@ -26,7 +27,7 @@ namespace Lithium
 {
     public class Core : MelonMod
     {
-        public static readonly List<ModuleBase> Modules = 
+        public static readonly List<ModuleBase> Modules =
         [
             new ModPropertyPrices(),
             new ModPlants(),
@@ -41,7 +42,8 @@ namespace Lithium
             new ModEmployees(),
             new ModChemistryStation(),
             new ModWateringCan(),
-            new ModEffectCombos()
+            new ModEffectCombos(),
+            new ModVehiclePrices()
         ];
 
         public static T Get<T>() where T : ModuleBase => Modules.OfType<T>().FirstOrDefault();

--- a/Lithium.csproj
+++ b/Lithium.csproj
@@ -540,6 +540,8 @@
 		<Compile Include="Modules\StackSizes\Patches\RegistryStartPatch.cs" />
 		<Compile Include="Modules\TrashGrabber\ModTrashGrabber.cs" />
 		<Compile Include="Modules\TrashGrabber\Patches\EquippableTrashGrabberGetCapacityPatch.cs" />
+		<Compile Include="Modules\VehiclePrices\ModVehiclePrices.cs" />
+		<Compile Include="Modules\VehiclePrices\Patches\ForceVehiclePrices.cs" />
 		<Compile Include="Util\SuccessChanceCalculator.cs" />
 		<Compile Include="Util\WeightedNormalizer.cs" />
 		<Compile Include="Util\WeightedPicker.cs" />
@@ -549,6 +551,6 @@
 	</ItemGroup>
 	
 	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="COPY &quot;$(TargetPath)&quot; &quot;$(ScheduleGamePath)\Mods&quot;" />
+		<Copy SourceFiles="$(TargetPath)" DestinationFolder="$(ScheduleGamePath)\Mods" Retries="60" />
 	</Target>
 </Project>

--- a/Modules/Shops/ModShops.cs
+++ b/Modules/Shops/ModShops.cs
@@ -16,6 +16,19 @@ namespace Lithium.Modules.Shops
         public Dictionary<string, float> PriceOverrides { get; set; } = [];
     }
 
+    public class SkateboardShopSettings
+    {
+        public string UIContainer;
+        public Dictionary<string, SkateboardListingOverride> SkateboardOverrides = [];
+    }
+
+    public class SkateboardListingOverride
+    {
+        public string UIPath;
+        public float Price;
+        public bool IsAvailable { get; set; } = true;
+    }
+
     public class ItemListingOverride
     {
         public float Price { get; set; }
@@ -34,7 +47,7 @@ namespace Lithium.Modules.Shops
         [JsonConverter(typeof(StringEnumConverter))]
         [JsonProperty(Order = 3)]
         public ShopInterface.EPaymentType PaymentType { get; set; }
-        
+
         [JsonProperty(Order = 6)]
         public Dictionary<string, ItemListingOverride> ItemOverrides = [];
     }
@@ -43,7 +56,7 @@ namespace Lithium.Modules.Shops
 
     public class DeliverySettings
     {
-        [JsonConverter(typeof(StringEnumConverter))] 
+        [JsonConverter(typeof(StringEnumConverter))]
         public DeliveryAvailabilitySettings Availability { get; set; } = DeliveryAvailabilitySettings.Unchanged;
         public float DeliveryFee { get; set; } = 200;
         public int XPRequirement { get; set; } = 0;
@@ -69,6 +82,8 @@ namespace Lithium.Modules.Shops
         public SupplierListingOverride Salvador;
 
         public Dictionary<string, DeliverySettings> Deliveries { get; set; }
+
+        public Dictionary<string, SkateboardShopSettings> SkateboardShops { get; set; }
     }
 
     public class ModShops : ModuleBase<ModShopsConfiguration>
@@ -77,6 +92,6 @@ namespace Lithium.Modules.Shops
         {
         }
 
-        
+
     }
 }

--- a/Modules/Shops/Patches/SupplierStartPatch.cs
+++ b/Modules/Shops/Patches/SupplierStartPatch.cs
@@ -1,10 +1,15 @@
 ﻿using HarmonyLib;
+using Il2CppScheduleOne.Dialogue;
 using Il2CppScheduleOne.Economy;
+using Il2CppScheduleOne.Money;
 using Il2CppScheduleOne.NPCs.CharacterClasses;
 using Il2CppScheduleOne.PlayerScripts;
 using Il2CppScheduleOne.UI.Phone;
 using Il2CppScheduleOne.UI.Shop;
+using Il2CppTMPro;
 using Lithium.Helper;
+using MelonLoader;
+using UnityEngine;
 
 namespace Lithium.Modules.Shops.Patches
 {
@@ -15,13 +20,60 @@ namespace Lithium.Modules.Shops.Patches
         public static void PatchPrices()
         {
             ModShopsConfiguration configuration = Core.Get<ModShops>().Configuration;
-            if(!configuration.Enabled)
+            if (!configuration.Enabled)
                 return;
 
             ApplyShopOverrides();
             //ApplySupplierOverrides();
+            ApplySkateboardOverrides();
             configuration.SaveConfiguration();
         }
+
+        private static void ApplySkateboardOverrides()
+        {
+            ModShopsConfiguration configuration = Core.Get<ModShops>().Configuration;
+
+            DialogueController_SkateboardSeller[] dialogueControllers = UnityEngine.Object.FindObjectsOfType<DialogueController_SkateboardSeller>();
+            foreach (DialogueController_SkateboardSeller shop in dialogueControllers)
+            {
+
+                if (!configuration.SkateboardShops.TryGetValue(shop.gameObject.transform.parent?.name, out SkateboardShopSettings settings))
+                {
+                    MelonLogger.Warning($"Skate store, {shop.gameObject.transform.parent?.name}, not found in configuration");
+                    continue;
+                }
+
+                foreach (DialogueController_SkateboardSeller.Option listing in shop.Options)
+                {
+                    if (!settings.SkateboardOverrides.TryGetValue(listing.Item.ID, out SkateboardListingOverride overrideBoard))
+                    {
+                        MelonLogger.Warning($"Skateboard, {listing.Item.ID}, not found in configuration");
+                        continue;
+                    }
+
+                    listing.Price = overrideBoard.Price;
+                    listing.IsAvailable = overrideBoard.IsAvailable;
+                    UIUpdates(listing.Name, settings, overrideBoard);
+                }
+            }
+
+            static void UIUpdates(String name, SkateboardShopSettings shop, SkateboardListingOverride skateboard)
+            {
+                GameObject sign = UnityEngine.GameObject.Find($"{shop.UIContainer}/{skateboard.UIPath}");
+                if (sign == null)
+                {
+                    MelonLogger.Warning($"Unable to find skateboard sign path: {shop.UIContainer}/{skateboard.UIPath}");
+                    return;
+                }
+                if (!sign.TryGetComponent<TextMeshPro>(out TextMeshPro priceText))
+                {
+                    MelonLogger.Warning($"Unable to find text component for: {shop.UIContainer}/{skateboard.UIPath}");
+                    return;
+                }
+                priceText.SetText($"{name}\n{MoneyManager.FormatAmount(skateboard.Price)}");
+            }
+        }
+
 
         private static void ApplySupplierOverrides()
         {

--- a/Modules/VehiclePrices/ModVehiclePrices.cs
+++ b/Modules/VehiclePrices/ModVehiclePrices.cs
@@ -1,0 +1,17 @@
+﻿namespace Lithium.Modules.VehiclePrices
+{
+    public class ModVehiclePricesConfiguration : ModuleConfiguration
+    {
+        public override string Name => "Vehicle Prices";
+        public Dictionary<string, int> VehiclePrices { get; set; }
+    }
+
+    public class ModVehiclePrices : ModuleBase<ModVehiclePricesConfiguration>
+    {
+        public override void Apply()
+        {
+            if (!Configuration.Enabled)
+                return;
+        }
+    }
+}

--- a/Modules/VehiclePrices/Patches/ForceVehiclePrices.cs
+++ b/Modules/VehiclePrices/Patches/ForceVehiclePrices.cs
@@ -1,0 +1,68 @@
+﻿using HarmonyLib;
+using Il2CppScheduleOne.Dialogue;
+using Il2CppScheduleOne.Money;
+using Il2CppScheduleOne.PlayerScripts;
+using Il2CppTMPro;
+using Il2CppScheduleOne.Property;
+using Il2CppScheduleOne.Vehicles;
+using Il2CppScheduleOne.Tools;
+using Il2CppSystem.IO.Compression;
+using Microsoft.VisualBasic;
+using Unity.Collections;
+using Lithium.Helper;
+
+namespace Lithium.Modules.VehiclePrices.Patches
+{
+    [HarmonyPatch(typeof(Player), nameof(Player.NetworkInitialize__Late))]
+    public class ForceVehiclePrices
+    {
+        [HarmonyPrefix]
+        public static void PatchPrices()
+        {
+            ModVehiclePricesConfiguration configuration = Core.Get<ModVehiclePrices>().Configuration;
+            if (!configuration.Enabled)
+                return;
+
+            ChangeVehiclePrices(configuration);
+            configuration.SaveConfiguration();
+        }
+
+        private static void ChangeVehiclePrices(ModVehiclePricesConfiguration configuration)
+        {
+            void UpdateSign(LandVehicle vehicle)
+            {
+                bool found = false;
+
+                foreach (VehicleSaleSign sign in UnityEngine.Object.FindObjectsOfType<VehicleSaleSign>())
+                {
+                    if (sign.NameLabel.text == vehicle.vehicleName)
+                    {
+                        found = true;
+                        sign.transform.Find("Price").GetComponent<TextMeshPro>().text =
+                            MoneyManager.FormatAmount(vehicle.vehiclePrice);
+                        break;
+                    }
+                }
+                if (!found)
+                {
+                    MelonLoader.MelonLogger.Warning($"Vehicle Sale Sign for {vehicle.vehicleName} not found in game.");
+                }
+            }
+
+            VehicleManager manager = UnityEngine.Object.FindObjectOfType<VehicleManager>();
+            foreach (LandVehicle vehicle in manager.VehiclePrefabs)
+            {
+                if (configuration.VehiclePrices.TryGetValue(vehicle.vehicleName, out int price))
+                {
+                    vehicle.vehiclePrice = price;
+                    UpdateSign(vehicle);
+                }
+                else
+                {
+                    MelonLoader.MelonLogger.Warning($"Vehicle {vehicle.vehicleName} not found in configuration. Skipping.");
+                    continue;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Here are the configuration examples I use with these changes

`Shops.json`
``` Shops.json
 "SkateboardShops": {
    "Jeff": {
      "UIContainer": "Map/Container/North town/Jeff's Shred Shack/Shred Shack/Catalog",
      "SkateboardOverrides": {
        "cheapskateboard": {
          "UIPath": "Paper (1)/Text (TMP)",
          "Price": 800.0,
          "IsAvailable": true
        },
        "skateboard": {
          "UIPath": "Paper (2)/Text (TMP)",
          "Price": 1250.0,
          "IsAvailable": true
        },
        "cruiser": {
          "UIPath": "Paper (3)/Text (TMP)",
          "Price": 2850.0,
          "IsAvailable": true
        },
        "lightweightskateboard": {
          "UIPath": "Paper (4)/Text (TMP)",
          "Price": 2850.0,
          "IsAvailable": true
        },
        "goldenskateboard": {
          "UIPath": "Paper (5)/Text (TMP)",
          "Price": 5000.0,
          "IsAvailable": true
        },
        "offroadskateboard": {
          "UIPath": "Paper (6)/Text (TMP)",
          "Price": 5000.0,
          "IsAvailable": true
        }
      }
    }
```

`Vehicle Prices.json`
``` Vehicle Prices.json
{
  "Enabled": true,
  "VehiclePrices": {
    "Shitbox": 18800,
    "Veeper": 52000,
    "Bruiser": 38000,
    "Dinkler": 55000,
    "Hounddog": 46000,
    "Cheetah": 120000,
    "Hotbox": 42000
  }
}
```